### PR TITLE
feat: support command: prefix in keymap actions

### DIFF
--- a/src/modules/vim/vimee.test.ts
+++ b/src/modules/vim/vimee.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import type { KeyEvent } from "@opentui/core"
+import type { PromptContext } from "../../prompt/types"
+import { createVimConfig } from "./config"
+import type { VimLog } from "./log"
+import { createVimState, type VimMode } from "./state"
+import { createVimeeAdapter } from "./vimee"
+
+describe("vim command keymaps", () => {
+    test("does not restore stale cursor state after a normal command", () => {
+        const fixture = createFixture("normal", "command:test.run")
+        fixture.dispatch = () => {
+            fixture.input.plainText = "updated"
+            fixture.input.cursorOffset = 7
+        }
+
+        expect(fixture.handle()).toBe(true)
+        expect(fixture.commands).toEqual(["test.run"])
+        expect(fixture.input.cursorOffset).toBe(7)
+    })
+
+    test("uses the host history boundary and restores display width", () => {
+        const fixture = createFixture("normal", "command:prompt.history.next", "中")
+        let boundary = -1
+        fixture.dispatch = () => {
+            boundary = fixture.input.cursorOffset
+            fixture.input.plainText = "中中"
+            fixture.input.cursorOffset = 2
+        }
+
+        expect(fixture.handle()).toBe(true)
+        expect(boundary).toBe(1)
+        expect(fixture.input.cursorOffset).toBe(4)
+    })
+
+    test("dispatches commands in insert mode", () => {
+        const fixture = createFixture("insert", "command:test.run")
+
+        expect(fixture.handle()).toBe(true)
+        expect(fixture.commands).toEqual(["test.run"])
+    })
+
+    test("rejects an empty command name", () => {
+        const logs: Array<[string, unknown]> = []
+        createFixture("normal", "command:   ", "", (event, data) => logs.push([event, data]))
+
+        expect(logs.some(([event]) => event === "vimee.keymap.invalid")).toBe(true)
+    })
+})
+
+function createFixture(mode: VimMode, action: string, text = "text", log: VimLog = () => {}) {
+    const input = {
+        plainText: text,
+        cursorOffset: 0,
+        visualCursor: { visualRow: 0, visualCol: 0, offset: 0 },
+        moveCursorLeft: () => false,
+    }
+    const commands: string[] = []
+    const prompt = {
+        current: { input: text, mode: "normal", parts: [] },
+        set() {},
+        submit() {},
+        blur() {},
+    }
+    const fixture = {
+        input,
+        commands,
+        dispatch: (_command: string) => {},
+        handle: () => adapter.handle({ name: "Q" } as KeyEvent, "Q", ctx),
+    }
+    const ctx = {
+        api: {
+            renderer: { currentFocusedRenderable: input },
+            keymap: {
+                dispatchCommand(command: string) {
+                    commands.push(command)
+                    fixture.dispatch(command)
+                },
+            },
+        },
+        prompt: () => prompt,
+        requestRender() {},
+    } as unknown as PromptContext
+    const config = createVimConfig({ defaultMode: mode, keymaps: { [mode]: { Q: action } } })
+    const adapter = createVimeeAdapter(createVimState(mode), config, log)
+    return fixture
+}

--- a/src/modules/vim/vimee.ts
+++ b/src/modules/vim/vimee.ts
@@ -9,9 +9,9 @@ import { createPromptMap, derivePromptMap, hostOffset, hostPosition, type Prompt
 import type { createVimState } from "./state"
 
 type VimState = ReturnType<typeof createVimState>
-type HostAction = VimeeAction | { type: "submit" }
-type HostKeybindAction = "normal" | "submit"
-type HostKeybindDefinition = KeybindDefinition & { hostAction?: HostKeybindAction }
+type HostAction = VimeeAction | { type: "submit" } | { type: "command"; command: string }
+type HostKeybindAction = "normal" | "submit" | "command"
+type HostKeybindDefinition = KeybindDefinition & { hostAction?: HostKeybindAction; command?: string }
 type HostRange = { start: number; end: number }
 
 const YANK_FLASH_MS = 250
@@ -164,6 +164,7 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                     break
                 case "cursor-move":
                     setCursor(input, currentMap, action.position)
+                    syncVisualCursor(input)
                     break
                 case "mode-change":
                     nativeInsertUndoSaved = false
@@ -174,6 +175,18 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                     break
                 case "submit":
                     ref.submit()
+                    break
+                case "command":
+                    if (input) {
+                        const textLen = input.plainText?.length ?? 0
+                        if (action.command === "prompt.history.previous") {
+                            input.cursorOffset = 0
+                        } else if (action.command === "prompt.history.next") {
+                            input.cursorOffset = textLen
+                        }
+                        syncVisualCursor(input)
+                    }
+                    ctx.api.keymap.dispatchCommand(action.command)
                     break
             }
         }
@@ -227,6 +240,22 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                 return true
             case "submit":
                 ctx.prompt()?.submit()
+                return true
+            case "command":
+                {
+                    const input = focusedInput(ctx)
+                    if (input) {
+                        const textLen = input.plainText?.length ?? 0
+                        const cmd = (definition as HostKeybindDefinition).command!
+                        if (cmd === "prompt.history.previous") {
+                            input.cursorOffset = 0
+                        } else if (cmd === "prompt.history.next") {
+                            input.cursorOffset = textLen
+                        }
+                        syncVisualCursor(input)
+                    }
+                    ctx.api.keymap.dispatchCommand((definition as HostKeybindDefinition).command!)
+                }
                 return true
             default:
                 return false
@@ -549,6 +578,19 @@ function clampNormalCursor(input: EditBufferLike) {
     if (cursor.visualRow === eol.visualRow && (cursor.offset === eol.offset || offset === eol.offset)) input.cursorOffset = Math.max(0, offset - 1)
 }
 
+function syncVisualCursor(input: EditBufferLike | undefined) {
+    if (!input?.visualCursor || input.plainText === undefined) return
+    const text = input.plainText
+    const offset = input.cursorOffset ?? 0
+    const before = text.slice(0, offset)
+    const row = before.split('\n').length - 1
+    const lastNewline = before.lastIndexOf('\n')
+    const col = offset - lastNewline - 1
+    input.visualCursor.visualRow = row
+    input.visualCursor.visualCol = col
+    input.visualCursor.offset = offset
+}
+
 function endMotionOffset(text: string, offset: number, count: number) {
     let index = offset
     for (let step = 0; step < count; step++) {
@@ -590,6 +632,14 @@ function createKeybinds(config: VimConfig, log: VimLog): KeybindMap | undefined 
 }
 
 function keybindAction(action: string): HostKeybindDefinition {
+    if (action.startsWith("command:")) {
+        const command = action.slice(8)
+        return {
+            execute: () => [{ type: "command", command } as unknown as VimeeAction],
+            hostAction: "command",
+            command,
+        }
+    }
     switch (action) {
         case "normal":
             return { keys: "<Esc>", hostAction: "normal" }

--- a/src/modules/vim/vimee.ts
+++ b/src/modules/vim/vimee.ts
@@ -167,7 +167,6 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                     break
                 case "cursor-move":
                     setCursor(input, currentMap, action.position)
-                    syncVisualCursor(input)
                     break
                 case "mode-change":
                     nativeInsertUndoSaved = false
@@ -180,17 +179,8 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                     ref.submit()
                     break
                 case "command":
-                    if (input) {
-                        const textLen = input.plainText?.length ?? 0
-                        if (action.command === "prompt.history.previous") {
-                            input.cursorOffset = 0
-                        } else if (action.command === "prompt.history.next") {
-                            input.cursorOffset = textLen
-                        }
-                        syncVisualCursor(input)
-                    }
-                    ctx.api.keymap.dispatchCommand(action.command)
-                    break
+                    dispatchCommand(action.command, ctx)
+                    return
             }
         }
 
@@ -245,20 +235,7 @@ export function createVimeeAdapter(state: VimState, config: VimConfig, log: VimL
                 ctx.prompt()?.submit()
                 return true
             case "command":
-                {
-                    const input = focusedInput(ctx)
-                    if (input) {
-                        const textLen = input.plainText?.length ?? 0
-                        const cmd = (definition as HostKeybindDefinition).command!
-                        if (cmd === "prompt.history.previous") {
-                            input.cursorOffset = 0
-                        } else if (cmd === "prompt.history.next") {
-                            input.cursorOffset = textLen
-                        }
-                        syncVisualCursor(input)
-                    }
-                    ctx.api.keymap.dispatchCommand((definition as HostKeybindDefinition).command!)
-                }
+                dispatchCommand((definition as HostKeybindDefinition).command!, ctx)
                 return true
             default:
                 return false
@@ -592,17 +569,18 @@ function clampNormalCursor(input: EditBufferLike) {
     }
 }
 
-function syncVisualCursor(input: EditBufferLike | undefined) {
-    if (!input?.visualCursor || input.plainText === undefined) return
-    const text = input.plainText
-    const offset = input.cursorOffset ?? 0
-    const before = text.slice(0, offset)
-    const row = before.split('\n').length - 1
-    const lastNewline = before.lastIndexOf('\n')
-    const col = offset - lastNewline - 1
-    input.visualCursor.visualRow = row
-    input.visualCursor.visualCol = col
-    input.visualCursor.offset = offset
+function dispatchCommand(command: string, ctx: PromptContext) {
+    const input = focusedInput(ctx)
+    if (command === "prompt.history.previous" && input) input.cursorOffset = 0
+    if (command === "prompt.history.next" && input) input.cursorOffset = input.plainText?.length ?? 0
+
+    ctx.api.keymap.dispatchCommand(command)
+
+    // The host currently checks history-next using character length, then leaves
+    // the cursor in that unit. Restore the display-width offset after dispatch.
+    if (command !== "prompt.history.next") return
+    const nextInput = focusedInput(ctx)
+    if (nextInput?.plainText !== undefined) nextInput.cursorOffset = displayWidth(nextInput.plainText)
 }
 
 function endMotionOffset(text: string, offset: number, count: number) {
@@ -647,7 +625,8 @@ function createKeybinds(config: VimConfig, log: VimLog): KeybindMap | undefined 
 
 function keybindAction(action: string): HostKeybindDefinition {
     if (action.startsWith("command:")) {
-        const command = action.slice(8)
+        const command = action.slice(8).trim()
+        if (!command) throw new Error("Command name is required")
         return {
             execute: () => [{ type: "command", command } as unknown as VimeeAction],
             hostAction: "command",


### PR DESCRIPTION
## Summary

Add `command:` prefix support to keymap actions. Users can now bind arbitrary opencode commands via the vim plugin keymaps.

## Usage

```jsonc
"keymaps": {
  "normal": {
    "<C-k>": "command:prompt.history.previous",
    "<C-j>": "command:prompt.history.next"
  },
  "insert": {
    "<C-k>": "command:prompt.history.previous",
    "<C-j>": "command:prompt.history.next"
  }
}
```

Available commands can be found in opencode source: `packages/tui/src/component/prompt/index.tsx` and `packages/tui/src/config/keybind.ts`.

## Notes

- For `prompt.history.previous` and `prompt.history.next`, the vim plugin automatically moves the cursor to the start/end before dispatching. If you prefer the default opencode behavior (cursor must already be at the start/end, otherwise first press only moves cursor), configure these keybinds in opencode's own `keybinds` config instead of the vim plugin's keymaps.
- English `configuration.md` and Chinese documentation will be updated once PR #14 (`feat/cr-mode-aware`) is merged. This PR contains only the implementation.